### PR TITLE
CMake: Set minimum version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # along with OpenShot Library. If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.2...3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12...3.20 FATAL_ERROR)
 
 message("\
 -----------------------------------------------------------------


### PR DESCRIPTION
Linking OBJECT libraries into SHARED targets (a trick to avoid recompilation of the bundled jsoncpp) means the build fails on all CMake versions through 3.11.

(Originally discussed via email. Solved on the project builders by @jonoomph, with an upgrade to CMake 3.20.2 on Linux. Windows was already on 3.20.1 following MSYS2 update, macOS is running 3.19.1.)

Technically CMake versions earlier than 3.12 will work _**if**_ a precompiled system jsoncpp is used, but I'd rather only declare compatibility with versions for which we maintain unqualified support.